### PR TITLE
Add Travis CI for automated tests

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,24 @@
+---
+
+language: node_js
+
+node_js:
+  - 10/*
+
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-5-dev
+
+install:
+  - npm i -g @elementaryos/houston
+
+script:
+  - houston ci


### PR DESCRIPTION
I highly recommend you to configure Travis CI with your repo for automated tests.

Here is the configuration file for Travis CI.

However, adding the travis.yml file is not enough. You have to register in Travis CI too if you want to use Continuous Integration (highly recommended). See the wiki here for further info https://github.com/elementary/houston/wiki/Continuous-Integration